### PR TITLE
Fix Airplane mode on 21.04

### DIFF
--- a/debian/patches/pop-rfkill.patch
+++ b/debian/patches/pop-rfkill.patch
@@ -1,0 +1,84 @@
+Index: gnome-settings-daemon/plugins/rfkill/rfkill-glib.c
+===================================================================
+--- gnome-settings-daemon.orig/plugins/rfkill/rfkill-glib.c	2021-07-19 07:14:52.890160468 -0600
++++ gnome-settings-daemon/plugins/rfkill/rfkill-glib.c	2021-07-19 07:22:25.095976688 -0600
+@@ -342,7 +342,7 @@
+ 
+ 	if (condition & G_IO_IN) {
+ 		GIOStatus status;
+-		struct rfkill_event event;
++		struct rfkill_event event = { 0 };
+ 		gsize read;
+ 
+ 		status = g_io_channel_read_chars (source,
+@@ -351,7 +351,7 @@
+ 						  &read,
+ 						  NULL);
+ 
+-		while (status == G_IO_STATUS_NORMAL && read == sizeof(event)) {
++		while (status == G_IO_STATUS_NORMAL && read >= RFKILL_EVENT_SIZE_V1) {
+ 			struct rfkill_event *event_ptr;
+ 
+ 			print_event (&event);
+@@ -389,7 +389,6 @@
+ {
+ 	int fd;
+ 	int ret;
+-	GList *events;
+ 
+ 	g_return_val_if_fail (CC_RFKILL_IS_GLIB (rfkill), FALSE);
+ 	g_return_val_if_fail (rfkill->stream == NULL, FALSE);
+@@ -411,52 +410,15 @@
+ 		return FALSE;
+ 	}
+ 
+-	events = NULL;
+-
+-	while (1) {
+-		struct rfkill_event event;
+-		struct rfkill_event *event_ptr;
+-		ssize_t len;
+-
+-		len = read(fd, &event, sizeof(event));
+-		if (len < 0) {
+-			if (errno == EAGAIN)
+-				break;
+-			g_debug ("Reading of RFKILL events failed");
+-			break;
+-		}
+-
+-		if (len != RFKILL_EVENT_SIZE_V1) {
+-			g_warning ("Wrong size of RFKILL event\n");
+-			continue;
+-		}
+-
+-		if (event.op != RFKILL_OP_ADD)
+-			continue;
+-
+-		g_debug ("Read killswitch of type '%s' (idx=%d): soft %d hard %d",
+-			 type_to_string (event.type),
+-			 event.idx, event.soft, event.hard);
+-
+-		event_ptr = g_memdup (&event, sizeof(event));
+-		events = g_list_prepend (events, event_ptr);
+-	}
+-
+ 	/* Setup monitoring */
+ 	rfkill->channel = g_io_channel_unix_new (fd);
+ 	g_io_channel_set_encoding (rfkill->channel, NULL, NULL);
++	g_io_channel_set_buffered (rfkill->channel, FALSE);
+ 	rfkill->watch_id = g_io_add_watch (rfkill->channel,
+ 					   G_IO_IN | G_IO_HUP | G_IO_ERR,
+ 					   (GIOFunc) event_cb,
+ 					   rfkill);
+ 
+-	if (events) {
+-		events = g_list_reverse (events);
+-		emit_changed_signal_and_free (rfkill, events);
+-	} else {
+-		g_debug ("No rfkill device available on startup");
+-	}
+-
+ 	/* Setup write stream */
+ 	rfkill->stream = g_unix_output_stream_new (fd, TRUE);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -34,3 +34,4 @@ smarcard-Add-utility-function-to-get-the-login-token-name.patch
 
 # Pop!_OS patches
 oled_brightness.patch
+pop-rfkill.patch


### PR DESCRIPTION
Cherry-pick upstream commits for rfkill to fix Airplane mode.

- d7a414cbdb4 ("rfkill: set the g_io_channel to unbuffered mode")
- f6ce8d3f1a7 ("rfkill: Fix rfkill event read length check")
- 1ec87c5e989 ("rfkill: Do not sync state immediately when opening rfkill")

Resolves: #9 